### PR TITLE
Fix notifications

### DIFF
--- a/src/clock.worker.ts
+++ b/src/clock.worker.ts
@@ -1,46 +1,26 @@
 let running: boolean = false
-let start: number | undefined
-let startTime: number | undefined
-let interval: number
-let prev: number | undefined
+let timerId: ReturnType<typeof setInterval> | undefined
 let lowFps: boolean = false
 
-const tick = (t: number): void => {
-    if (running) {
-        if (start === undefined) {
-            start = t
-            prev = t
-            requestAnimationFrame(tick)
-        } else {
-            interval += t - prev!
-            if (lowFps) {
-                if (interval >= 1000) {
-                    self.postMessage(interval)
-                    interval = 0
-                }
-            } else {
-                self.postMessage(t - prev!)
-            }
-            requestAnimationFrame(tick)
-
-            prev = t
-        }
-    }
-}
+// Tick interval in milliseconds
+const TICK_INTERVAL = 100
+const LOW_FPS_INTERVAL = 1000
 
 self.onmessage = async ({ data }) => {
     if (data.start) {
         lowFps = data.lowFps
         if (!running) {
             running = true
-            interval = 0
-            startTime = new Date().getTime()
-            requestAnimationFrame(tick)
+            const interval = lowFps ? LOW_FPS_INTERVAL : TICK_INTERVAL
+            timerId = setInterval(() => {
+                self.postMessage(interval)
+            }, interval)
         }
     } else {
         running = false
-        start = undefined
-        startTime = undefined
-        prev = undefined
+        if (timerId !== undefined) {
+            clearInterval(timerId)
+            timerId = undefined
+        }
     }
 }

--- a/src/components/Timer.ts
+++ b/src/components/Timer.ts
@@ -232,9 +232,8 @@ export default class Timer implements Readable<TimerStore> {
 
     private notify(state: TimerState, logFile: TFile | void) {
         const emoji = state.mode == 'WORK' ? '🍅' : '🥤'
-        const text = `${emoji} You have been ${
-            state.mode === 'WORK' ? 'working' : 'breaking'
-        } for ${state.duration} minutes.`
+        const text = `${emoji} You have been ${state.mode === 'WORK' ? 'working' : 'breaking'
+            } for ${state.duration} minutes.`
 
         if (this.plugin.getSettings().useSystemNotification) {
             const sysNotification = new Notification('Pomodoro Timer', {

--- a/src/components/Timer.ts
+++ b/src/components/Timer.ts
@@ -13,346 +13,343 @@ import DEFAULT_NOTIFICATION from '@components/Notification'
 
 export type Mode = 'WORK' | 'BREAK'
 export type TimerRemained = {
-	millis: number
-	human: string
+    millis: number
+    human: string
 }
 
 const DEFAULT_TASK: TaskItem = {
-	actual: 0,
-	expected: 0,
-	path: '',
-	fileName: '',
-	text: '',
-	name: '',
-	status: '',
-	blockLink: '',
-	checked: false,
-	done: '',
-	due: '',
-	created: '',
-	cancelled: '',
-	scheduled: '',
-	start: '',
-	description: '',
-	priority: '',
-	recurrence: '',
-	tags: [],
-	line: -1,
+    actual: 0,
+    expected: 0,
+    path: '',
+    fileName: '',
+    text: '',
+    name: '',
+    status: '',
+    blockLink: '',
+    checked: false,
+    done: '',
+    due: '',
+    created: '',
+    cancelled: '',
+    scheduled: '',
+    start: '',
+    description: '',
+    priority: '',
+    recurrence: '',
+    tags: [],
+    line: -1,
 }
 
 export type TimerState = {
-	autostart: boolean
-	running: boolean
-	// lastTick: number
-	mode: Mode
-	elapsed: number
-	startTime: number | null
-	inSession: boolean
-	workLen: number
-	breakLen: number
-	count: number
-	duration: number
+    autostart: boolean
+    running: boolean
+    // lastTick: number
+    mode: Mode
+    elapsed: number
+    startTime: number | null
+    inSession: boolean
+    workLen: number
+    breakLen: number
+    count: number
+    duration: number
 }
 
 export type TimerStore = TimerState & {
-	remained: TimerRemained
-	finished: boolean
+    remained: TimerRemained
+    finished: boolean
 }
 
 export default class Timer implements Readable<TimerStore> {
-	static DEFAULT_NOTIFICATION_AUDIO = new Audio(DEFAULT_NOTIFICATION)
+    static DEFAULT_NOTIFICATION_AUDIO = new Audio(DEFAULT_NOTIFICATION)
 
-	private plugin: PomodoroTimerPlugin
+    private plugin: PomodoroTimerPlugin
 
-	private logger: Logger
+    private logger: Logger
 
-	private state: TimerState
+    private state: TimerState
 
-	private store: Readable<TimerStore>
+    private store: Readable<TimerStore>
 
-	private clock: any
+    private clock: any
 
-	private update
+    private update
 
-	private unsubscribers: Unsubscriber[] = []
+    private unsubscribers: Unsubscriber[] = []
 
-	public subscribe
+    public subscribe
 
-	constructor(plugin: PomodoroTimerPlugin) {
-		this.plugin = plugin
-		this.logger = new Logger(plugin)
-		let count = this.toMillis(plugin.getSettings().workLen)
-		this.state = {
-			autostart: plugin.getSettings().autostart,
-			workLen: plugin.getSettings().workLen,
-			breakLen: plugin.getSettings().breakLen,
-			running: false,
-			// lastTick: 0,
-			mode: 'WORK',
-			elapsed: 0,
-			startTime: null,
-			inSession: false,
-			duration: plugin.getSettings().workLen,
-			count,
-		}
+    constructor(plugin: PomodoroTimerPlugin) {
+        this.plugin = plugin
+        this.logger = new Logger(plugin)
+        let count = this.toMillis(plugin.getSettings().workLen)
+        this.state = {
+            autostart: plugin.getSettings().autostart,
+            workLen: plugin.getSettings().workLen,
+            breakLen: plugin.getSettings().breakLen,
+            running: false,
+            // lastTick: 0,
+            mode: 'WORK',
+            elapsed: 0,
+            startTime: null,
+            inSession: false,
+            duration: plugin.getSettings().workLen,
+            count,
+        }
 
-		let store = writable(this.state)
+        let store = writable(this.state)
 
-		this.update = store.update
+        this.update = store.update
 
-		this.store = derived(store, ($state) => ({
-			...$state,
-			remained: this.remain($state.count, $state.elapsed),
-			finished: $state.count == $state.elapsed,
-		}))
+        this.store = derived(store, ($state) => ({
+            ...$state,
+            remained: this.remain($state.count, $state.elapsed),
+            finished: $state.count == $state.elapsed,
+        }))
 
-		this.subscribe = this.store.subscribe
-		this.unsubscribers.push(
-			this.store.subscribe((state) => {
-				this.state = state
-			}),
-		)
-		this.clock = Worker()
-		this.clock.onmessage = ({ data }: any) => {
-			this.tick(data as number)
-		}
-	}
+        this.subscribe = this.store.subscribe
+        this.unsubscribers.push(
+            this.store.subscribe((state) => {
+                this.state = state
+            }),
+        )
+        this.clock = Worker()
+        this.clock.onmessage = ({ data }: any) => {
+            this.tick(data as number)
+        }
+    }
 
-	private remain(count: number, elapsed: number): TimerRemained {
-		let remained = count - elapsed
-		let min = Math.floor(remained / 60000)
-		let sec = Math.floor((remained % 60000) / 1000)
-		let minStr = min < 10 ? `0${min}` : min.toString()
-		let secStr = sec < 10 ? `0${sec}` : sec.toString()
-		return {
-			millis: remained,
-			human: `${minStr} : ${secStr}`,
-		}
-	}
+    private remain(count: number, elapsed: number): TimerRemained {
+        let remained = count - elapsed
+        let min = Math.floor(remained / 60000)
+        let sec = Math.floor((remained % 60000) / 1000)
+        let minStr = min < 10 ? `0${min}` : min.toString()
+        let secStr = sec < 10 ? `0${sec}` : sec.toString()
+        return {
+            millis: remained,
+            human: `${minStr} : ${secStr}`,
+        }
+    }
 
-	private toMillis(minutes: number) {
-		return minutes * 60 * 1000
-	}
+    private toMillis(minutes: number) {
+        return minutes * 60 * 1000
+    }
 
-	private tick(t: number) {
-		let timeup: boolean = false
-		let pause: boolean = false
-		this.update((s) => {
-			if (s.running) {
-				s.elapsed += t
-				if (s.elapsed >= s.count) {
-					s.elapsed = s.count
-				}
-				timeup = s.elapsed >= s.count
-			} else {
-				pause = true
-			}
-			return s
-		})
-		if (!pause && timeup) {
-			this.timeup()
-		}
-	}
+    private tick(t: number) {
+        let timeup: boolean = false
+        let pause: boolean = false
+        this.update((s) => {
+            if (s.running) {
+                s.elapsed += t
+                if (s.elapsed >= s.count) {
+                    s.elapsed = s.count
+                }
+                timeup = s.elapsed >= s.count
+            } else {
+                pause = true
+            }
+            return s
+        })
+        if (!pause && timeup) {
+            this.timeup()
+        }
+    }
 
-	private timeup() {
-		let autostart = false
-		this.update((state) => {
-			const ctx = this.createLogContext(state)
-			this.processLog(ctx)
-			autostart = state.autostart
-			return this.endSession(state)
-		})
-		if (autostart) {
-			this.start()
-		}
-	}
+    private timeup() {
+        let autostart = false
+        this.update((state) => {
+            const ctx = this.createLogContext(state)
+            this.processLog(ctx)
+            autostart = state.autostart
+            return this.endSession(state)
+        })
+        if (autostart) {
+            this.start()
+        }
+    }
 
-	private createLogContext(s: TimerState): LogContext {
-		let state = { ...s }
-		let comment = this.plugin.tracker?.comment ?? ''
-		let task = this.plugin.tracker?.task
-			? { ...this.plugin.tracker.task }
-			: { ...DEFAULT_TASK }
+    private createLogContext(s: TimerState): LogContext {
+        let state = { ...s }
+        let comment = this.plugin.tracker?.comment ?? ''
+        let task = this.plugin.tracker?.task
+            ? { ...this.plugin.tracker.task }
+            : { ...DEFAULT_TASK }
 
-		if (!task.path) {
-			task.path = this.plugin.tracker?.file?.path ?? ''
-			task.fileName = this.plugin.tracker?.file?.name ?? ''
-		}
+        if (!task.path) {
+            task.path = this.plugin.tracker?.file?.path ?? ''
+            task.fileName = this.plugin.tracker?.file?.name ?? ''
+        }
 
-		return { ...state, task, comment: comment }
-	}
+        return { ...state, task, comment: comment }
+    }
 
-	private async processLog(ctx: LogContext) {
-		if (ctx.mode == 'WORK') {
-			await this.plugin.tracker?.updateActual()
-		}
-		const logFile = await this.logger.log(ctx)
-		this.notify(ctx, logFile)
-	}
+    private async processLog(ctx: LogContext) {
+        if (ctx.mode == 'WORK') {
+            await this.plugin.tracker?.updateActual()
+        }
+        const logFile = await this.logger.log(ctx)
+        this.notify(ctx, logFile)
+    }
 
-	public start() {
-		this.update((s) => {
-			let now = new Date().getTime()
-			if (!s.inSession) {
-				// new session
-				s.elapsed = 0
-				s.duration = s.mode === 'WORK' ? s.workLen : s.breakLen
-				s.count = s.duration * 60 * 1000
-				s.startTime = now
-			}
-			s.inSession = true
-			s.running = true
-			this.clock.postMessage({
-				start: true,
-				lowFps: this.plugin.getSettings().lowFps,
-			})
-			return s
-		})
-	}
+    public start() {
+        this.update((s) => {
+            let now = new Date().getTime()
+            if (!s.inSession) {
+                // new session
+                s.elapsed = 0
+                s.duration = s.mode === 'WORK' ? s.workLen : s.breakLen
+                s.count = s.duration * 60 * 1000
+                s.startTime = now
+            }
+            s.inSession = true
+            s.running = true
+            this.clock.postMessage({
+                start: true,
+                lowFps: this.plugin.getSettings().lowFps,
+            })
+            return s
+        })
+    }
 
-	private endSession(state: TimerState) {
-		// setup new session
-		if (state.breakLen == 0) {
-			state.mode = 'WORK'
-		} else {
-			state.mode = state.mode == 'WORK' ? 'BREAK' : 'WORK'
-		}
-		state.duration = state.mode == 'WORK' ? state.workLen : state.breakLen
-		state.count = state.duration * 60 * 1000
-		state.inSession = false
-		state.running = false
-		this.clock.postMessage({
-			start: false,
-			lowFps: this.plugin.getSettings().lowFps,
-		})
-		state.startTime = null
-		state.elapsed = 0
-		return state
-	}
+    private endSession(state: TimerState) {
+        // setup new session
+        if (state.breakLen == 0) {
+            state.mode = 'WORK'
+        } else {
+            state.mode = state.mode == 'WORK' ? 'BREAK' : 'WORK'
+        }
+        state.duration = state.mode == 'WORK' ? state.workLen : state.breakLen
+        state.count = state.duration * 60 * 1000
+        state.inSession = false
+        state.running = false
+        this.clock.postMessage({
+            start: false,
+            lowFps: this.plugin.getSettings().lowFps,
+        })
+        state.startTime = null
+        state.elapsed = 0
+        return state
+    }
 
-	private notify(state: TimerState, logFile: TFile | void) {
-		const emoji = state.mode == 'WORK' ? '🍅' : '🥤'
-		const text = `${emoji} You have been ${state.mode === 'WORK' ? 'working' : 'breaking'
-			} for ${state.duration} minutes.`
+    private notify(state: TimerState, logFile: TFile | void) {
+        const emoji = state.mode == 'WORK' ? '🍅' : '🥤'
+        const text = `${emoji} You have been ${
+            state.mode === 'WORK' ? 'working' : 'breaking'
+        } for ${state.duration} minutes.`
 
-		if (this.plugin.getSettings().useSystemNotification) {
-			const Notification = (require('electron') as any).remote
-				.Notification
-			const sysNotification = new Notification({
-				title: 'Pomodoro Timer',
-				body: text,
-				silent: true,
-			})
-			sysNotification.on('click', () => {
-				if (logFile) {
-					this.plugin.app.workspace.getLeaf('split').openFile(logFile)
-				}
-				sysNotification.close()
-			})
-			sysNotification.show()
-		} else {
-			let fragment = new DocumentFragment()
-			let span = fragment.createEl('span')
-			span.setText(`${text}`)
-			fragment.addEventListener('click', () => {
-				if (logFile) {
-					this.plugin.app.workspace.getLeaf('split').openFile(logFile)
-				}
-			})
-			new Notice(fragment)
-		}
+        if (this.plugin.getSettings().useSystemNotification) {
+            const sysNotification = new Notification('Pomodoro Timer', {
+                body: text,
+                silent: true,
+            })
+            sysNotification.onclick = () => {
+                if (logFile) {
+                    this.plugin.app.workspace.getLeaf('split').openFile(logFile)
+                }
+                sysNotification.close()
+            }
+        } else {
+            let fragment = new DocumentFragment()
+            let span = fragment.createEl('span')
+            span.setText(`${text}`)
+            fragment.addEventListener('click', () => {
+                if (logFile) {
+                    this.plugin.app.workspace.getLeaf('split').openFile(logFile)
+                }
+            })
+            new Notice(fragment)
+        }
 
-		if (this.plugin.getSettings().notificationSound) {
-			this.playAudio()
-		}
-	}
+        if (this.plugin.getSettings().notificationSound) {
+            this.playAudio()
+        }
+    }
 
-	public pause() {
-		this.update((state) => {
-			state.running = false
-			this.clock.postMessage({
-				start: false,
-				lowFps: this.plugin.getSettings().lowFps,
-			})
-			return state
-		})
-	}
+    public pause() {
+        this.update((state) => {
+            state.running = false
+            this.clock.postMessage({
+                start: false,
+                lowFps: this.plugin.getSettings().lowFps,
+            })
+            return state
+        })
+    }
 
-	public reset() {
-		this.update((state) => {
-			if (state.elapsed > 0) {
-				this.logger.log(this.createLogContext(state))
-			}
+    public reset() {
+        this.update((state) => {
+            if (state.elapsed > 0) {
+                this.logger.log(this.createLogContext(state))
+            }
 
-			state.duration =
-				state.mode == 'WORK' ? state.workLen : state.breakLen
-			state.count = state.duration * 60 * 1000
-			state.inSession = false
-			state.running = false
+            state.duration =
+                state.mode == 'WORK' ? state.workLen : state.breakLen
+            state.count = state.duration * 60 * 1000
+            state.inSession = false
+            state.running = false
 
-			if (!this.plugin.tracker!.pinned) {
-				this.plugin.tracker!.clear()
-			}
-			this.clock.postMessage({
-				start: false,
-				lowFps: this.plugin.getSettings().lowFps,
-			})
-			state.startTime = null
-			state.elapsed = 0
-			return state
-		})
-	}
+            if (!this.plugin.tracker!.pinned) {
+                this.plugin.tracker!.clear()
+            }
+            this.clock.postMessage({
+                start: false,
+                lowFps: this.plugin.getSettings().lowFps,
+            })
+            state.startTime = null
+            state.elapsed = 0
+            return state
+        })
+    }
 
-	public toggleMode(callback?: (state: TimerState) => void) {
-		this.update((s) => {
-			let updated = this.endSession(s)
-			if (callback) {
-				callback(updated)
-			}
-			return updated
-		})
-	}
+    public toggleMode(callback?: (state: TimerState) => void) {
+        this.update((s) => {
+            let updated = this.endSession(s)
+            if (callback) {
+                callback(updated)
+            }
+            return updated
+        })
+    }
 
-	public toggleTimer() {
-		this.state.running ? this.pause() : this.start()
-	}
+    public toggleTimer() {
+        this.state.running ? this.pause() : this.start()
+    }
 
-	public playAudio() {
-		let audio = Timer.DEFAULT_NOTIFICATION_AUDIO
-		let customSound = this.plugin.getSettings().customSound
-		if (customSound) {
-			const soundFile =
-				this.plugin.app.vault.getAbstractFileByPath(customSound)
-			if (soundFile && soundFile instanceof TFile) {
-				const soundSrc =
-					this.plugin.app.vault.getResourcePath(soundFile)
-				audio = new Audio(soundSrc)
-			}
-		}
-		audio.play()
-	}
+    public playAudio() {
+        let audio = Timer.DEFAULT_NOTIFICATION_AUDIO
+        let customSound = this.plugin.getSettings().customSound
+        if (customSound) {
+            const soundFile =
+                this.plugin.app.vault.getAbstractFileByPath(customSound)
+            if (soundFile && soundFile instanceof TFile) {
+                const soundSrc =
+                    this.plugin.app.vault.getResourcePath(soundFile)
+                audio = new Audio(soundSrc)
+            }
+        }
+        audio.play()
+    }
 
-	public setupTimer() {
-		this.update((state) => {
-			const { workLen, breakLen, autostart } = this.plugin.getSettings()
-			state.workLen = workLen
-			state.breakLen = breakLen
-			state.autostart = autostart
-			if (!state.running && !state.inSession) {
-				state.duration =
-					state.mode == 'WORK' ? state.workLen : state.breakLen
-				state.count = state.duration * 60 * 1000
-			}
+    public setupTimer() {
+        this.update((state) => {
+            const { workLen, breakLen, autostart } = this.plugin.getSettings()
+            state.workLen = workLen
+            state.breakLen = breakLen
+            state.autostart = autostart
+            if (!state.running && !state.inSession) {
+                state.duration =
+                    state.mode == 'WORK' ? state.workLen : state.breakLen
+                state.count = state.duration * 60 * 1000
+            }
 
-			return state
-		})
-	}
+            return state
+        })
+    }
 
-	public destroy() {
-		this.pause()
-		this.clock?.terminate()
-		for (let unsub of this.unsubscribers) {
-			unsub()
-		}
-	}
+    public destroy() {
+        this.pause()
+        this.clock?.terminate()
+        for (let unsub of this.unsubscribers) {
+            unsub()
+        }
+    }
 }


### PR DESCRIPTION
I use virtual desktops a lot in my workflow and often use a single physical monitor. I like to have the Pomodoro plugin running in the background, but I was not getting notifications when Obsidian was out of focus.

This is caused by the fact that the clock worker relies on `requestAnimationFrame`, which only runs when Obsidian is actually being rendered. I don't see how the animations are better thanks to that as the timer is second based and has no option of displaying milliseconds. A `setInterval` of `100ms` is entirely sufficient in this case and actually save resources, as we really don't need to check if a second has passed 160 times per second (my monitor refresh rate).

Additionally, I changed the notification API being used from the deprecated Electron remote API to the renderer based web API. 