### PR TITLE
Add reminders

### DIFF
--- a/src/components/Settings.ts
+++ b/src/components/Settings.ts
@@ -5,9 +5,9 @@ import type { Unsubscriber } from 'svelte/motion'
 import { writable, type Writable } from 'svelte/store'
 
 import {
-	appHasDailyNotesPluginLoaded,
-	appHasWeeklyNotesPluginLoaded,
-	getTemplater,
+    appHasDailyNotesPluginLoaded,
+    appHasWeeklyNotesPluginLoaded,
+    getTemplater,
 } from '@utils/utils'
 
 type LogFileType = 'DAILY' | 'WEEKLY' | 'FILE' | 'NONE'
@@ -16,318 +16,386 @@ type LogFormat = 'SIMPLE' | 'VERBOSE' | 'CUSTOM'
 export type TaskFormat = 'TASKS' | 'DATAVIEW'
 
 export interface Settings {
-	workLen: number
-	breakLen: number
-	autostart: boolean
-	useStatusBarTimer: boolean
-	notificationSound: boolean
-	enableTaskTracking: boolean
-	showTaskProgress: boolean
-	customSound: string
-	logFile: LogFileType
-	logFocused: boolean
-	logPath: string
-	logLevel: LogLevel
-	logTemplate: string
-	logFormat: LogFormat
-	useSystemNotification: boolean
-	taskFormat: TaskFormat
-	lowFps: boolean
+    workLen: number
+    breakLen: number
+    autostart: boolean
+    useStatusBarTimer: boolean
+    notificationSound: boolean
+    enableReminders: boolean
+    reminderIntervals: string
+    reminderSound: string
+    enableTaskTracking: boolean
+    showTaskProgress: boolean
+    customSound: string
+    logFile: LogFileType
+    logFocused: boolean
+    logPath: string
+    logLevel: LogLevel
+    logTemplate: string
+    logFormat: LogFormat
+    useSystemNotification: boolean
+    taskFormat: TaskFormat
+    lowFps: boolean
 }
 
 export default class PomodoroSettings extends PluginSettingTab {
-	static readonly DEFAULT_SETTINGS: Settings = {
-		workLen: 25,
-		breakLen: 5,
-		autostart: false,
-		useStatusBarTimer: false,
-		notificationSound: true,
-		customSound: '',
-		showTaskProgress: true,
-		enableTaskTracking: false,
-		logFile: 'NONE',
-		logFocused: false,
-		logPath: '',
-		logLevel: 'ALL',
-		logTemplate: '',
-		logFormat: 'VERBOSE',
-		useSystemNotification: false,
-		taskFormat: 'TASKS',
-		lowFps: false,
-	}
+    static readonly DEFAULT_SETTINGS: Settings = {
+        workLen: 25,
+        breakLen: 5,
+        autostart: false,
+        useStatusBarTimer: false,
+        notificationSound: true,
+        enableReminders: true,
+        reminderIntervals: '30, 60, 120',
+        reminderSound: '',
+        customSound: '',
+        showTaskProgress: true,
+        enableTaskTracking: false,
+        logFile: 'NONE',
+        logFocused: false,
+        logPath: '',
+        logLevel: 'ALL',
+        logTemplate: '',
+        logFormat: 'VERBOSE',
+        useSystemNotification: false,
+        taskFormat: 'TASKS',
+        lowFps: false,
+    }
 
-	static settings: Writable<Settings> = writable(
-		PomodoroSettings.DEFAULT_SETTINGS,
-	)
+    static settings: Writable<Settings> = writable(
+        PomodoroSettings.DEFAULT_SETTINGS,
+    )
 
-	private _settings: Settings
+    private _settings: Settings
 
-	private plugin: PomodoroTimerPlugin
+    private plugin: PomodoroTimerPlugin
 
-	private unsubscribe: Unsubscriber
+    private unsubscribe: Unsubscriber
 
-	constructor(plugin: PomodoroTimerPlugin, settings: Settings) {
-		super(plugin.app, plugin)
-		this.plugin = plugin
-		this._settings = { ...PomodoroSettings.DEFAULT_SETTINGS, ...settings }
-		PomodoroSettings.settings.set(this._settings)
-		this.unsubscribe = PomodoroSettings.settings.subscribe((settings) => {
-			this.plugin.saveData(settings)
-			this._settings = settings
-			this.plugin.timer?.setupTimer()
-		})
-	}
+    constructor(plugin: PomodoroTimerPlugin, settings: Settings) {
+        super(plugin.app, plugin)
+        this.plugin = plugin
+        this._settings = { ...PomodoroSettings.DEFAULT_SETTINGS, ...settings }
+        PomodoroSettings.settings.set(this._settings)
+        this.unsubscribe = PomodoroSettings.settings.subscribe((settings) => {
+            this.plugin.saveData(settings)
+            this._settings = settings
+            this.plugin.timer?.setupTimer()
+        })
+    }
 
-	public getSettings(): Settings {
-		return this._settings
-	}
+    public getSettings(): Settings {
+        return this._settings
+    }
 
-	public updateSettings = (
-		newSettings: Partial<Settings>,
-		refreshUI: boolean = false,
-	) => {
-		PomodoroSettings.settings.update((settings) => {
-			this._settings = { ...settings, ...newSettings }
-			if (refreshUI) {
-				this.display()
-			}
-			return this._settings
-		})
-	}
+    public updateSettings = (
+        newSettings: Partial<Settings>,
+        refreshUI: boolean = false,
+    ) => {
+        PomodoroSettings.settings.update((settings) => {
+            this._settings = { ...settings, ...newSettings }
+            if (refreshUI) {
+                this.display()
+            }
+            return this._settings
+        })
+    }
 
-	public unload() {
-		this.unsubscribe()
-	}
+    public unload() {
+        this.unsubscribe()
+    }
 
-	public display() {
-		const { containerEl } = this
-		containerEl.empty()
+    public display() {
+        const { containerEl } = this
+        containerEl.empty()
 
-		new Setting(containerEl)
-			.setName('Enable Status Bar Timer')
-			.addToggle((toggle) => {
-				toggle.setValue(this._settings.useStatusBarTimer)
-				toggle.onChange((value) => {
-					this.updateSettings({ useStatusBarTimer: value })
-				})
-			})
+        new Setting(containerEl)
+            .setName('Enable Status Bar Timer')
+            .addToggle((toggle) => {
+                toggle.setValue(this._settings.useStatusBarTimer)
+                toggle.onChange((value) => {
+                    this.updateSettings({ useStatusBarTimer: value })
+                })
+            })
 
-		new Setting(containerEl)
-			.setName('Low Animation FPS')
-			.setDesc("If you encounter high CPU usage, you can enable this option to lower the animation FPS to save CPU resources")
-			.addToggle((toggle) => {
-				toggle.setValue(this._settings.lowFps)
-				toggle.onChange((value: boolean) => {
-					this.updateSettings({ lowFps: value })
-				})
-			})
+        new Setting(containerEl)
+            .setName('Low Animation FPS')
+            .setDesc(
+                'If you encounter high CPU usage, you can enable this option to lower the animation FPS to save CPU resources',
+            )
+            .addToggle((toggle) => {
+                toggle.setValue(this._settings.lowFps)
+                toggle.onChange((value: boolean) => {
+                    this.updateSettings({ lowFps: value })
+                })
+            })
 
-		new Setting(containerEl).setHeading().setName('Notification')
+        new Setting(containerEl).setHeading().setName('Notification')
 
-		new Setting(containerEl)
-			.setName('Use System Notification')
-			.addToggle((toggle) => {
-				toggle.setValue(this._settings.useSystemNotification)
-				toggle.onChange((value) => {
-					this.updateSettings({ useSystemNotification: value })
-				})
-			})
-		new Setting(containerEl)
-			.setName('Sound Notification')
-			.addToggle((toggle) => {
-				toggle.setValue(this._settings.notificationSound)
-				toggle.onChange((value) => {
-					this.updateSettings({ notificationSound: value }, true)
-				})
-			})
+        new Setting(containerEl)
+            .setName('Use System Notification')
+            .addToggle((toggle) => {
+                toggle.setValue(this._settings.useSystemNotification)
+                toggle.onChange((value) => {
+                    this.updateSettings({ useSystemNotification: value })
+                })
+            })
+        new Setting(containerEl)
+            .setName('Sound Notification')
+            .addToggle((toggle) => {
+                toggle.setValue(this._settings.notificationSound)
+                toggle.onChange((value) => {
+                    this.updateSettings({ notificationSound: value }, true)
+                })
+            })
 
-		if (this._settings.notificationSound) {
-			new Setting(containerEl)
-				.setName('Custom Notification Audio')
-				.addText((text) => {
-					text.inputEl.style.width = '100%'
-					text.setPlaceholder('path/to/sound.mp3')
-					text.setValue(this._settings.customSound)
-					text.onChange((value) => {
-						this.updateSettings({ customSound: value })
-					})
-				})
-				.addExtraButton((button) => {
-					button.setIcon('play')
-					button.setTooltip('play')
-					button.onClick(() => {
-						this.plugin.timer?.playAudio()
-					})
-				})
-		}
+        if (this._settings.notificationSound) {
+            new Setting(containerEl)
+                .setName('Custom Notification Audio')
+                .addText((text) => {
+                    text.inputEl.style.width = '100%'
+                    text.setPlaceholder('path/to/sound.mp3')
+                    text.setValue(this._settings.customSound)
+                    text.onChange((value) => {
+                        this.updateSettings({ customSound: value })
+                    })
+                })
+                .addExtraButton((button) => {
+                    button.setIcon('play')
+                    button.setTooltip('play')
+                    button.onClick(() => {
+                        this.plugin.timer?.playAudio()
+                    })
+                })
+        }
 
-		new Setting(containerEl).setHeading().setName('Task')
-		new Setting(containerEl)
-			.setName('Enable Task Tracking')
-			.setDesc(
-				'Important: Enabling this feature will automatically add a block ID when activating a task, unless a block ID is already present.',
-			)
-			.addToggle((toggle) => {
-				toggle.setValue(this._settings.enableTaskTracking)
-				toggle.onChange((value) => {
-					this.updateSettings({ enableTaskTracking: value })
-				})
-			})
-		new Setting(containerEl)
-			.setName('Show Task Progress Background')
-			.addToggle((toggle) => {
-				toggle.setValue(this._settings.showTaskProgress)
-				toggle.onChange((value) => {
-					this.updateSettings({ showTaskProgress: value })
-				})
-			})
-		new Setting(containerEl)
-			.setName('Task Format')
-			.addDropdown((dropdown) => {
-				dropdown.selectEl.style.width = '160px'
-				dropdown.addOptions({
-					TASKS: 'Tasks Emoji Format',
-					DATAVIEW: 'Dataview',
-				})
-				dropdown.setValue(this._settings.taskFormat)
-				dropdown.onChange((value: string) => {
-					this.updateSettings(
-						{ taskFormat: value as TaskFormat },
-						true,
-					)
-				})
-			})
+        new Setting(containerEl)
+            .setName('Enable Reminders')
+            .setDesc(
+                'Send reminders when auto-start is off and next session is not started',
+            )
+            .addToggle((toggle) => {
+                toggle.setValue(this._settings.enableReminders)
+                toggle.onChange((value) => {
+                    this.updateSettings({ enableReminders: value }, true)
+                })
+            })
 
-		new Setting(containerEl).setHeading().setName('Log')
-		new Setting(containerEl).setName('Log File').addDropdown((dropdown) => {
-			dropdown.selectEl.style.width = '160px'
-			dropdown.addOptions({ NONE: 'None' })
-			if (appHasDailyNotesPluginLoaded()) {
-				dropdown.addOptions({ DAILY: 'Daily note' })
-			}
-			if (appHasWeeklyNotesPluginLoaded()) {
-				dropdown.addOptions({ WEEKLY: 'Weekly note' })
-			}
-			dropdown.addOptions({ FILE: 'File' })
-			dropdown.setValue(this._settings.logFile)
-			dropdown.onChange((value: string) => {
-				this.updateSettings({ logFile: value as LogFileType }, true)
-			})
-		})
+        if (this._settings.enableReminders) {
+            const parseIntervals = (input: string): number[] => {
+                return input
+                    .split(',')
+                    .map((s) => parseInt(s.trim()))
+                    .filter((n) => !isNaN(n) && n > 0)
+                    .sort((a, b) => a - b)
+            }
 
-		if (this._settings.logFile != 'NONE') {
-			if (this._settings.logFile === 'FILE') {
-				new Setting(containerEl)
-					.setName('Log file path')
-					.setDesc('The file to log pomodoro sessions to')
-					.addText((text) => {
-						text.inputEl.style.width = '300px'
-						text.setValue(this._settings.logPath)
-						text.onChange((value) => {
-							this.updateSettings({ logPath: value })
-						})
-					})
-			}
+            const parsed = parseIntervals(this._settings.reminderIntervals)
+            const intervalDesc =
+                parsed.length > 0
+                    ? `Current: ${parsed.map((n) => `${n}s`).join(', ')}`
+                    : 'No valid intervals'
 
-			new Setting(containerEl)
-				.setName('Log Level')
-				.addDropdown((dropdown) => {
-					dropdown.selectEl.style.width = '160px'
-					dropdown.addOptions({
-						ALL: 'All',
-						WORK: 'Work',
-						BREAK: 'Break',
-					})
-					dropdown.setValue(this._settings.logLevel)
-					dropdown.onChange((value: string) => {
-						this.updateSettings({ logLevel: value as LogLevel })
-					})
-				})
+            new Setting(containerEl)
+                .setName('Reminder Intervals')
+                .setDesc(
+                    `Comma-separated seconds after session ends. ${intervalDesc}`,
+                )
+                .addText((text) => {
+                    text.inputEl.style.width = '150px'
+                    text.setPlaceholder('30, 60, 120')
+                    text.setValue(this._settings.reminderIntervals)
+                    text.onChange((value) => {
+                        this.updateSettings({ reminderIntervals: value }, true)
+                    })
+                })
 
-			const hasTemplater = !!getTemplater(this.app)
+            new Setting(containerEl)
+                .setName('Custom Reminder Sound')
+                .setDesc('Leave empty to use main notification sound')
+                .addText((text) => {
+                    text.inputEl.style.width = '100%'
+                    text.setPlaceholder('path/to/sound.mp3')
+                    text.setValue(this._settings.reminderSound)
+                    text.onChange((value) => {
+                        this.updateSettings({ reminderSound: value })
+                    })
+                })
+                .addExtraButton((button) => {
+                    button.setIcon('play')
+                    button.setTooltip('play')
+                    button.onClick(() => {
+                        this.plugin.timer?.playReminderAudio()
+                    })
+                })
+        }
 
-			let example = ''
-			if (this._settings.logFormat == 'SIMPLE') {
-				example = `**WORK(25m)**: from ${moment()
-					.subtract(25, 'minutes')
-					.format('HH:mm')} - ${moment().format('HH:mm')}`
-			}
-			if (this._settings.logFormat == 'VERBOSE') {
-				example = `- 🍅 (pomodoro::WORK) (duration:: 25m) (begin:: ${moment()
-					.subtract(25, 'minutes')
-					.format('YYYY-MM-DD HH:mm')}) - (end:: ${moment().format(
-						'YYYY-MM-DD HH:mm',
-					)})`
-			}
-			new Setting(containerEl)
-				.setName('Log Format')
-				.setDesc(example)
-				.addDropdown((dropdown) => {
-					dropdown.selectEl.style.width = '160px'
-					dropdown.addOptions({
-						SIMPLE: 'Simple',
-						VERBOSE: 'Verbose',
-						CUSTOM: 'Custom',
-					})
-					dropdown.setValue(this._settings.logFormat)
+        new Setting(containerEl).setHeading().setName('Task')
+        new Setting(containerEl)
+            .setName('Enable Task Tracking')
+            .setDesc(
+                'Important: Enabling this feature will automatically add a block ID when activating a task, unless a block ID is already present.',
+            )
+            .addToggle((toggle) => {
+                toggle.setValue(this._settings.enableTaskTracking)
+                toggle.onChange((value) => {
+                    this.updateSettings({ enableTaskTracking: value })
+                })
+            })
+        new Setting(containerEl)
+            .setName('Show Task Progress Background')
+            .addToggle((toggle) => {
+                toggle.setValue(this._settings.showTaskProgress)
+                toggle.onChange((value) => {
+                    this.updateSettings({ showTaskProgress: value })
+                })
+            })
+        new Setting(containerEl)
+            .setName('Task Format')
+            .addDropdown((dropdown) => {
+                dropdown.selectEl.style.width = '160px'
+                dropdown.addOptions({
+                    TASKS: 'Tasks Emoji Format',
+                    DATAVIEW: 'Dataview',
+                })
+                dropdown.setValue(this._settings.taskFormat)
+                dropdown.onChange((value: string) => {
+                    this.updateSettings(
+                        { taskFormat: value as TaskFormat },
+                        true,
+                    )
+                })
+            })
 
-					dropdown.onChange((value: string) => {
-						this.updateSettings(
-							{ logFormat: value as LogFormat },
-							true,
-						)
-					})
-				})
+        new Setting(containerEl).setHeading().setName('Log')
+        new Setting(containerEl).setName('Log File').addDropdown((dropdown) => {
+            dropdown.selectEl.style.width = '160px'
+            dropdown.addOptions({ NONE: 'None' })
+            if (appHasDailyNotesPluginLoaded()) {
+                dropdown.addOptions({ DAILY: 'Daily note' })
+            }
+            if (appHasWeeklyNotesPluginLoaded()) {
+                dropdown.addOptions({ WEEKLY: 'Weekly note' })
+            }
+            dropdown.addOptions({ FILE: 'File' })
+            dropdown.setValue(this._settings.logFile)
+            dropdown.onChange((value: string) => {
+                this.updateSettings({ logFile: value as LogFileType }, true)
+            })
+        })
 
+        if (this._settings.logFile != 'NONE') {
+            if (this._settings.logFile === 'FILE') {
+                new Setting(containerEl)
+                    .setName('Log file path')
+                    .setDesc('The file to log pomodoro sessions to')
+                    .addText((text) => {
+                        text.inputEl.style.width = '300px'
+                        text.setValue(this._settings.logPath)
+                        text.onChange((value) => {
+                            this.updateSettings({ logPath: value })
+                        })
+                    })
+            }
 
-			if (this._settings.logFormat == 'CUSTOM') {
-				const logTemplate = new Setting(containerEl).setName(
-					'Log template',
-				)
-				if (hasTemplater) {
-					logTemplate.addTextArea((text) => {
-						text.inputEl.style.width = '100%'
-						text.inputEl.style.resize = 'vertical'
-						text.setPlaceholder('<% templater script goes here %>')
-						text.setValue(this._settings.logTemplate)
-						text.onChange((value) => {
-							this.updateSettings({ logTemplate: value })
-						})
-					})
-				} else {
-					logTemplate
-						.setDesc(
-							createFragment((fragment) => {
-								const text1 = document.createElement('span')
-								text1.setText('Requires ')
-								text1.style.color = 'var(--text-error)'
-								const a = document.createElement('a')
-								a.setText('Templater')
-								a.href =
-									'obsidian://show-plugin?id=templater-obsidian'
-								const text2 = document.createElement('span')
-								text2.setText(
-									' plugin to be enabled, then click the refresh button',
-								)
-								text2.style.color = 'var(--text-error)'
-								fragment.append(text1, a, text2)
-							}),
-						)
-						.addButton((button) => {
-							button.setIcon('refresh-ccw')
-							button.onClick(() => {
-								this.display()
-							})
-						})
-				}
-			}
-		}
+            new Setting(containerEl)
+                .setName('Log Level')
+                .addDropdown((dropdown) => {
+                    dropdown.selectEl.style.width = '160px'
+                    dropdown.addOptions({
+                        ALL: 'All',
+                        WORK: 'Work',
+                        BREAK: 'Break',
+                    })
+                    dropdown.setValue(this._settings.logLevel)
+                    dropdown.onChange((value: string) => {
+                        this.updateSettings({ logLevel: value as LogLevel })
+                    })
+                })
 
-		new Setting(containerEl).addButton((button) => {
-			button.setButtonText('Restore Settings')
-			button.onClick(() => {
-				this.updateSettings(PomodoroSettings.DEFAULT_SETTINGS, true)
-			})
-		})
-	}
+            const hasTemplater = !!getTemplater(this.app)
+
+            let example = ''
+            if (this._settings.logFormat == 'SIMPLE') {
+                example = `**WORK(25m)**: from ${moment()
+                    .subtract(25, 'minutes')
+                    .format('HH:mm')} - ${moment().format('HH:mm')}`
+            }
+            if (this._settings.logFormat == 'VERBOSE') {
+                example = `- 🍅 (pomodoro::WORK) (duration:: 25m) (begin:: ${moment()
+                    .subtract(25, 'minutes')
+                    .format('YYYY-MM-DD HH:mm')}) - (end:: ${moment().format(
+                    'YYYY-MM-DD HH:mm',
+                )})`
+            }
+            new Setting(containerEl)
+                .setName('Log Format')
+                .setDesc(example)
+                .addDropdown((dropdown) => {
+                    dropdown.selectEl.style.width = '160px'
+                    dropdown.addOptions({
+                        SIMPLE: 'Simple',
+                        VERBOSE: 'Verbose',
+                        CUSTOM: 'Custom',
+                    })
+                    dropdown.setValue(this._settings.logFormat)
+
+                    dropdown.onChange((value: string) => {
+                        this.updateSettings(
+                            { logFormat: value as LogFormat },
+                            true,
+                        )
+                    })
+                })
+
+            if (this._settings.logFormat == 'CUSTOM') {
+                const logTemplate = new Setting(containerEl).setName(
+                    'Log template',
+                )
+                if (hasTemplater) {
+                    logTemplate.addTextArea((text) => {
+                        text.inputEl.style.width = '100%'
+                        text.inputEl.style.resize = 'vertical'
+                        text.setPlaceholder('<% templater script goes here %>')
+                        text.setValue(this._settings.logTemplate)
+                        text.onChange((value) => {
+                            this.updateSettings({ logTemplate: value })
+                        })
+                    })
+                } else {
+                    logTemplate
+                        .setDesc(
+                            createFragment((fragment) => {
+                                const text1 = document.createElement('span')
+                                text1.setText('Requires ')
+                                text1.style.color = 'var(--text-error)'
+                                const a = document.createElement('a')
+                                a.setText('Templater')
+                                a.href =
+                                    'obsidian://show-plugin?id=templater-obsidian'
+                                const text2 = document.createElement('span')
+                                text2.setText(
+                                    ' plugin to be enabled, then click the refresh button',
+                                )
+                                text2.style.color = 'var(--text-error)'
+                                fragment.append(text1, a, text2)
+                            }),
+                        )
+                        .addButton((button) => {
+                            button.setIcon('refresh-ccw')
+                            button.onClick(() => {
+                                this.display()
+                            })
+                        })
+                }
+            }
+        }
+
+        new Setting(containerEl).addButton((button) => {
+            button.setButtonText('Restore Settings')
+            button.onClick(() => {
+                this.updateSettings(PomodoroSettings.DEFAULT_SETTINGS, true)
+            })
+        })
+    }
 }

--- a/src/components/Timer.ts
+++ b/src/components/Timer.ts
@@ -13,346 +13,423 @@ import DEFAULT_NOTIFICATION from '@components/Notification'
 
 export type Mode = 'WORK' | 'BREAK'
 export type TimerRemained = {
-	millis: number
-	human: string
+    millis: number
+    human: string
 }
 
 const DEFAULT_TASK: TaskItem = {
-	actual: 0,
-	expected: 0,
-	path: '',
-	fileName: '',
-	text: '',
-	name: '',
-	status: '',
-	blockLink: '',
-	checked: false,
-	done: '',
-	due: '',
-	created: '',
-	cancelled: '',
-	scheduled: '',
-	start: '',
-	description: '',
-	priority: '',
-	recurrence: '',
-	tags: [],
-	line: -1,
+    actual: 0,
+    expected: 0,
+    path: '',
+    fileName: '',
+    text: '',
+    name: '',
+    status: '',
+    blockLink: '',
+    checked: false,
+    done: '',
+    due: '',
+    created: '',
+    cancelled: '',
+    scheduled: '',
+    start: '',
+    description: '',
+    priority: '',
+    recurrence: '',
+    tags: [],
+    line: -1,
 }
 
 export type TimerState = {
-	autostart: boolean
-	running: boolean
-	// lastTick: number
-	mode: Mode
-	elapsed: number
-	startTime: number | null
-	inSession: boolean
-	workLen: number
-	breakLen: number
-	count: number
-	duration: number
+    autostart: boolean
+    running: boolean
+    // lastTick: number
+    mode: Mode
+    elapsed: number
+    startTime: number | null
+    inSession: boolean
+    workLen: number
+    breakLen: number
+    count: number
+    duration: number
 }
 
 export type TimerStore = TimerState & {
-	remained: TimerRemained
-	finished: boolean
+    remained: TimerRemained
+    finished: boolean
 }
 
 export default class Timer implements Readable<TimerStore> {
-	static DEFAULT_NOTIFICATION_AUDIO = new Audio(DEFAULT_NOTIFICATION)
+    static DEFAULT_NOTIFICATION_AUDIO = new Audio(DEFAULT_NOTIFICATION)
 
-	private plugin: PomodoroTimerPlugin
+    private plugin: PomodoroTimerPlugin
 
-	private logger: Logger
+    private logger: Logger
 
-	private state: TimerState
+    private state: TimerState
 
-	private store: Readable<TimerStore>
+    private store: Readable<TimerStore>
 
-	private clock: any
+    private clock: any
 
-	private update
+    private update
 
-	private unsubscribers: Unsubscriber[] = []
+    private unsubscribers: Unsubscriber[] = []
 
-	public subscribe
+    private reminderTimeouts: ReturnType<typeof setTimeout>[] = []
 
-	constructor(plugin: PomodoroTimerPlugin) {
-		this.plugin = plugin
-		this.logger = new Logger(plugin)
-		let count = this.toMillis(plugin.getSettings().workLen)
-		this.state = {
-			autostart: plugin.getSettings().autostart,
-			workLen: plugin.getSettings().workLen,
-			breakLen: plugin.getSettings().breakLen,
-			running: false,
-			// lastTick: 0,
-			mode: 'WORK',
-			elapsed: 0,
-			startTime: null,
-			inSession: false,
-			duration: plugin.getSettings().workLen,
-			count,
-		}
+    public subscribe
 
-		let store = writable(this.state)
+    constructor(plugin: PomodoroTimerPlugin) {
+        this.plugin = plugin
+        this.logger = new Logger(plugin)
+        let count = this.toMillis(plugin.getSettings().workLen)
+        this.state = {
+            autostart: plugin.getSettings().autostart,
+            workLen: plugin.getSettings().workLen,
+            breakLen: plugin.getSettings().breakLen,
+            running: false,
+            // lastTick: 0,
+            mode: 'WORK',
+            elapsed: 0,
+            startTime: null,
+            inSession: false,
+            duration: plugin.getSettings().workLen,
+            count,
+        }
 
-		this.update = store.update
+        let store = writable(this.state)
 
-		this.store = derived(store, ($state) => ({
-			...$state,
-			remained: this.remain($state.count, $state.elapsed),
-			finished: $state.count == $state.elapsed,
-		}))
+        this.update = store.update
 
-		this.subscribe = this.store.subscribe
-		this.unsubscribers.push(
-			this.store.subscribe((state) => {
-				this.state = state
-			}),
-		)
-		this.clock = Worker()
-		this.clock.onmessage = ({ data }: any) => {
-			this.tick(data as number)
-		}
-	}
+        this.store = derived(store, ($state) => ({
+            ...$state,
+            remained: this.remain($state.count, $state.elapsed),
+            finished: $state.count == $state.elapsed,
+        }))
 
-	private remain(count: number, elapsed: number): TimerRemained {
-		let remained = count - elapsed
-		let min = Math.floor(remained / 60000)
-		let sec = Math.floor((remained % 60000) / 1000)
-		let minStr = min < 10 ? `0${min}` : min.toString()
-		let secStr = sec < 10 ? `0${sec}` : sec.toString()
-		return {
-			millis: remained,
-			human: `${minStr} : ${secStr}`,
-		}
-	}
+        this.subscribe = this.store.subscribe
+        this.unsubscribers.push(
+            this.store.subscribe((state) => {
+                this.state = state
+            }),
+        )
+        this.clock = Worker()
+        this.clock.onmessage = ({ data }: any) => {
+            this.tick(data as number)
+        }
+    }
 
-	private toMillis(minutes: number) {
-		return minutes * 60 * 1000
-	}
+    private remain(count: number, elapsed: number): TimerRemained {
+        let remained = count - elapsed
+        let min = Math.floor(remained / 60000)
+        let sec = Math.floor((remained % 60000) / 1000)
+        let minStr = min < 10 ? `0${min}` : min.toString()
+        let secStr = sec < 10 ? `0${sec}` : sec.toString()
+        return {
+            millis: remained,
+            human: `${minStr} : ${secStr}`,
+        }
+    }
 
-	private tick(t: number) {
-		let timeup: boolean = false
-		let pause: boolean = false
-		this.update((s) => {
-			if (s.running) {
-				s.elapsed += t
-				if (s.elapsed >= s.count) {
-					s.elapsed = s.count
-				}
-				timeup = s.elapsed >= s.count
-			} else {
-				pause = true
-			}
-			return s
-		})
-		if (!pause && timeup) {
-			this.timeup()
-		}
-	}
+    private toMillis(minutes: number) {
+        return minutes * 60 * 1000
+    }
 
-	private timeup() {
-		let autostart = false
-		this.update((state) => {
-			const ctx = this.createLogContext(state)
-			this.processLog(ctx)
-			autostart = state.autostart
-			return this.endSession(state)
-		})
-		if (autostart) {
-			this.start()
-		}
-	}
+    private tick(t: number) {
+        let timeup: boolean = false
+        let pause: boolean = false
+        this.update((s) => {
+            if (s.running) {
+                s.elapsed += t
+                if (s.elapsed >= s.count) {
+                    s.elapsed = s.count
+                }
+                timeup = s.elapsed >= s.count
+            } else {
+                pause = true
+            }
+            return s
+        })
+        if (!pause && timeup) {
+            this.timeup()
+        }
+    }
 
-	private createLogContext(s: TimerState): LogContext {
-		let state = { ...s }
-		let comment = this.plugin.tracker?.comment ?? ''
-		let task = this.plugin.tracker?.task
-			? { ...this.plugin.tracker.task }
-			: { ...DEFAULT_TASK }
+    private timeup() {
+        let autostart = false
+        this.update((state) => {
+            const ctx = this.createLogContext(state)
+            this.processLog(ctx)
+            autostart = state.autostart
+            return this.endSession(state)
+        })
+        if (autostart) {
+            this.start()
+        } else {
+            this.scheduleReminders()
+        }
+    }
 
-		if (!task.path) {
-			task.path = this.plugin.tracker?.file?.path ?? ''
-			task.fileName = this.plugin.tracker?.file?.name ?? ''
-		}
+    private createLogContext(s: TimerState): LogContext {
+        let state = { ...s }
+        let comment = this.plugin.tracker?.comment ?? ''
+        let task = this.plugin.tracker?.task
+            ? { ...this.plugin.tracker.task }
+            : { ...DEFAULT_TASK }
 
-		return { ...state, task, comment: comment }
-	}
+        if (!task.path) {
+            task.path = this.plugin.tracker?.file?.path ?? ''
+            task.fileName = this.plugin.tracker?.file?.name ?? ''
+        }
 
-	private async processLog(ctx: LogContext) {
-		if (ctx.mode == 'WORK') {
-			await this.plugin.tracker?.updateActual()
-		}
-		const logFile = await this.logger.log(ctx)
-		this.notify(ctx, logFile)
-	}
+        return { ...state, task, comment: comment }
+    }
 
-	public start() {
-		this.update((s) => {
-			let now = new Date().getTime()
-			if (!s.inSession) {
-				// new session
-				s.elapsed = 0
-				s.duration = s.mode === 'WORK' ? s.workLen : s.breakLen
-				s.count = s.duration * 60 * 1000
-				s.startTime = now
-			}
-			s.inSession = true
-			s.running = true
-			this.clock.postMessage({
-				start: true,
-				lowFps: this.plugin.getSettings().lowFps,
-			})
-			return s
-		})
-	}
+    private async processLog(ctx: LogContext) {
+        if (ctx.mode == 'WORK') {
+            await this.plugin.tracker?.updateActual()
+        }
+        const logFile = await this.logger.log(ctx)
+        this.notify(ctx, logFile)
+    }
 
-	private endSession(state: TimerState) {
-		// setup new session
-		if (state.breakLen == 0) {
-			state.mode = 'WORK'
-		} else {
-			state.mode = state.mode == 'WORK' ? 'BREAK' : 'WORK'
-		}
-		state.duration = state.mode == 'WORK' ? state.workLen : state.breakLen
-		state.count = state.duration * 60 * 1000
-		state.inSession = false
-		state.running = false
-		this.clock.postMessage({
-			start: false,
-			lowFps: this.plugin.getSettings().lowFps,
-		})
-		state.startTime = null
-		state.elapsed = 0
-		return state
-	}
+    public start() {
+        this.clearReminders()
+        this.update((s) => {
+            let now = new Date().getTime()
+            if (!s.inSession) {
+                // new session
+                s.elapsed = 0
+                s.duration = s.mode === 'WORK' ? s.workLen : s.breakLen
+                s.count = s.duration * 60 * 1000
+                s.startTime = now
+            }
+            s.inSession = true
+            s.running = true
+            this.clock.postMessage({
+                start: true,
+                lowFps: this.plugin.getSettings().lowFps,
+            })
+            return s
+        })
+    }
 
-	private notify(state: TimerState, logFile: TFile | void) {
-		const emoji = state.mode == 'WORK' ? '🍅' : '🥤'
-		const text = `${emoji} You have been ${state.mode === 'WORK' ? 'working' : 'breaking'
-			} for ${state.duration} minutes.`
+    private endSession(state: TimerState) {
+        // setup new session
+        if (state.breakLen == 0) {
+            state.mode = 'WORK'
+        } else {
+            state.mode = state.mode == 'WORK' ? 'BREAK' : 'WORK'
+        }
+        state.duration = state.mode == 'WORK' ? state.workLen : state.breakLen
+        state.count = state.duration * 60 * 1000
+        state.inSession = false
+        state.running = false
+        this.clock.postMessage({
+            start: false,
+            lowFps: this.plugin.getSettings().lowFps,
+        })
+        state.startTime = null
+        state.elapsed = 0
+        return state
+    }
 
-		if (this.plugin.getSettings().useSystemNotification) {
-			const Notification = (require('electron') as any).remote
-				.Notification
-			const sysNotification = new Notification({
-				title: 'Pomodoro Timer',
-				body: text,
-				silent: true,
-			})
-			sysNotification.on('click', () => {
-				if (logFile) {
-					this.plugin.app.workspace.getLeaf('split').openFile(logFile)
-				}
-				sysNotification.close()
-			})
-			sysNotification.show()
-		} else {
-			let fragment = new DocumentFragment()
-			let span = fragment.createEl('span')
-			span.setText(`${text}`)
-			fragment.addEventListener('click', () => {
-				if (logFile) {
-					this.plugin.app.workspace.getLeaf('split').openFile(logFile)
-				}
-			})
-			new Notice(fragment)
-		}
+    private notify(state: TimerState, logFile: TFile | void) {
+        const emoji = state.mode == 'WORK' ? '🍅' : '🥤'
+        const text = `${emoji} You have been ${
+            state.mode === 'WORK' ? 'working' : 'breaking'
+        } for ${state.duration} minutes.`
 
-		if (this.plugin.getSettings().notificationSound) {
-			this.playAudio()
-		}
-	}
+        if (this.plugin.getSettings().useSystemNotification) {
+            const sysNotification = new Notification('Pomodoro Timer', {
+                body: text,
+                silent: true,
+            })
+            sysNotification.onclick = () => {
+                if (logFile) {
+                    this.plugin.app.workspace.getLeaf('split').openFile(logFile)
+                }
+                sysNotification.close()
+            }
+        } else {
+            let fragment = new DocumentFragment()
+            let span = fragment.createEl('span')
+            span.setText(`${text}`)
+            fragment.addEventListener('click', () => {
+                if (logFile) {
+                    this.plugin.app.workspace.getLeaf('split').openFile(logFile)
+                }
+            })
+            new Notice(fragment)
+        }
 
-	public pause() {
-		this.update((state) => {
-			state.running = false
-			this.clock.postMessage({
-				start: false,
-				lowFps: this.plugin.getSettings().lowFps,
-			})
-			return state
-		})
-	}
+        if (this.plugin.getSettings().notificationSound) {
+            this.playAudio()
+        }
+    }
 
-	public reset() {
-		this.update((state) => {
-			if (state.elapsed > 0) {
-				this.logger.log(this.createLogContext(state))
-			}
+    public pause() {
+        this.update((state) => {
+            state.running = false
+            this.clock.postMessage({
+                start: false,
+                lowFps: this.plugin.getSettings().lowFps,
+            })
+            return state
+        })
+    }
 
-			state.duration =
-				state.mode == 'WORK' ? state.workLen : state.breakLen
-			state.count = state.duration * 60 * 1000
-			state.inSession = false
-			state.running = false
+    public reset() {
+        this.clearReminders()
+        this.update((state) => {
+            if (state.elapsed > 0) {
+                this.logger.log(this.createLogContext(state))
+            }
 
-			if (!this.plugin.tracker!.pinned) {
-				this.plugin.tracker!.clear()
-			}
-			this.clock.postMessage({
-				start: false,
-				lowFps: this.plugin.getSettings().lowFps,
-			})
-			state.startTime = null
-			state.elapsed = 0
-			return state
-		})
-	}
+            state.duration =
+                state.mode == 'WORK' ? state.workLen : state.breakLen
+            state.count = state.duration * 60 * 1000
+            state.inSession = false
+            state.running = false
 
-	public toggleMode(callback?: (state: TimerState) => void) {
-		this.update((s) => {
-			let updated = this.endSession(s)
-			if (callback) {
-				callback(updated)
-			}
-			return updated
-		})
-	}
+            if (!this.plugin.tracker!.pinned) {
+                this.plugin.tracker!.clear()
+            }
+            this.clock.postMessage({
+                start: false,
+                lowFps: this.plugin.getSettings().lowFps,
+            })
+            state.startTime = null
+            state.elapsed = 0
+            return state
+        })
+    }
 
-	public toggleTimer() {
-		this.state.running ? this.pause() : this.start()
-	}
+    public toggleMode(callback?: (state: TimerState) => void) {
+        this.update((s) => {
+            let updated = this.endSession(s)
+            if (callback) {
+                callback(updated)
+            }
+            return updated
+        })
+    }
 
-	public playAudio() {
-		let audio = Timer.DEFAULT_NOTIFICATION_AUDIO
-		let customSound = this.plugin.getSettings().customSound
-		if (customSound) {
-			const soundFile =
-				this.plugin.app.vault.getAbstractFileByPath(customSound)
-			if (soundFile && soundFile instanceof TFile) {
-				const soundSrc =
-					this.plugin.app.vault.getResourcePath(soundFile)
-				audio = new Audio(soundSrc)
-			}
-		}
-		audio.play()
-	}
+    public toggleTimer() {
+        this.state.running ? this.pause() : this.start()
+    }
 
-	public setupTimer() {
-		this.update((state) => {
-			const { workLen, breakLen, autostart } = this.plugin.getSettings()
-			state.workLen = workLen
-			state.breakLen = breakLen
-			state.autostart = autostart
-			if (!state.running && !state.inSession) {
-				state.duration =
-					state.mode == 'WORK' ? state.workLen : state.breakLen
-				state.count = state.duration * 60 * 1000
-			}
+    public playAudio() {
+        let audio = Timer.DEFAULT_NOTIFICATION_AUDIO
+        let customSound = this.plugin.getSettings().customSound
+        if (customSound) {
+            const soundFile =
+                this.plugin.app.vault.getAbstractFileByPath(customSound)
+            if (soundFile && soundFile instanceof TFile) {
+                const soundSrc =
+                    this.plugin.app.vault.getResourcePath(soundFile)
+                audio = new Audio(soundSrc)
+            }
+        }
+        audio.play()
+    }
 
-			return state
-		})
-	}
+    public playReminderAudio() {
+        let audio = Timer.DEFAULT_NOTIFICATION_AUDIO
+        const settings = this.plugin.getSettings()
+        const soundPath = settings.reminderSound || settings.customSound
+        if (soundPath) {
+            const soundFile =
+                this.plugin.app.vault.getAbstractFileByPath(soundPath)
+            if (soundFile && soundFile instanceof TFile) {
+                const soundSrc =
+                    this.plugin.app.vault.getResourcePath(soundFile)
+                audio = new Audio(soundSrc)
+            }
+        }
+        audio.play()
+    }
 
-	public destroy() {
-		this.pause()
-		this.clock?.terminate()
-		for (let unsub of this.unsubscribers) {
-			unsub()
-		}
-	}
+    private parseReminderIntervals(): number[] {
+        const input = this.plugin.getSettings().reminderIntervals
+        return input
+            .split(',')
+            .map((s) => parseInt(s.trim()))
+            .filter((n) => !isNaN(n) && n > 0)
+            .sort((a, b) => a - b)
+    }
+
+    private scheduleReminders() {
+        this.clearReminders()
+
+        const settings = this.plugin.getSettings()
+        if (!settings.enableReminders || settings.autostart) {
+            return
+        }
+
+        const intervals = this.parseReminderIntervals()
+        for (const seconds of intervals) {
+            const timeout = setTimeout(() => {
+                this.sendReminder()
+            }, seconds * 1000)
+            this.reminderTimeouts.push(timeout)
+        }
+    }
+
+    private clearReminders() {
+        for (const timeout of this.reminderTimeouts) {
+            clearTimeout(timeout)
+        }
+        this.reminderTimeouts = []
+    }
+
+    private sendReminder() {
+        const text = '🍅 Ready to start your next session?'
+
+        if (this.plugin.getSettings().useSystemNotification) {
+            const Notification = (require('electron') as any).remote
+                .Notification
+            const sysNotification = new Notification({
+                title: 'Pomodoro Timer',
+                body: text,
+                silent: true,
+            })
+            sysNotification.on('click', () => {
+                sysNotification.close()
+            })
+            sysNotification.show()
+        } else {
+            new Notice(text)
+        }
+
+        if (this.plugin.getSettings().notificationSound) {
+            this.playReminderAudio()
+        }
+    }
+
+    public setupTimer() {
+        this.update((state) => {
+            const { workLen, breakLen, autostart } = this.plugin.getSettings()
+            state.workLen = workLen
+            state.breakLen = breakLen
+            state.autostart = autostart
+            if (!state.running && !state.inSession) {
+                state.duration =
+                    state.mode == 'WORK' ? state.workLen : state.breakLen
+                state.count = state.duration * 60 * 1000
+            }
+
+            return state
+        })
+    }
+
+    public destroy() {
+        this.pause()
+        this.clearReminders()
+        this.clock?.terminate()
+        for (let unsub of this.unsubscribers) {
+            unsub()
+        }
+    }
 }


### PR DESCRIPTION
### Summary

Adds configurable reminder notifications when auto-start is disabled and the user hasn't started the next session after a completed pomodoro.

### Features

- **Configurable reminder intervals**: Set custom times (in seconds) for when reminders should fire after a session ends. Default: 30s, 60s, 120s
- **Custom reminder sound**: Optionally specify a different sound file for reminders, or use the main notification sound
- **Respects existing settings**: Uses system notifications if enabled, plays sound only if sound notifications are enabled
- **Smart cancellation**: Reminders are automatically cleared when the user starts a new session or resets the timer

### New Settings

| Setting | Default | Description |
|---------|---------|-------------|
| Enable Reminders | On | Toggle idle reminder notifications |
| Reminder Intervals | `30, 60, 120` | Comma-separated seconds after session ends |
| Custom Reminder Sound | (empty) | Path to custom sound file (uses main sound if empty) |

### How It Works

1. When a work or break session completes and auto-start is **off**, reminders are scheduled
2. At each configured interval, a notification appears: "🍅 Ready to start your next session?"
3. Once the user starts the next session or resets the timer, pending reminders are cancelled
4. After the final reminder fires, no more reminders are sent until the next session completes
